### PR TITLE
Adding new ability of producing a message without a prdocuer

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -66,6 +66,8 @@ type ConfigurationsUpdate struct {
 	Update      bool   `json:"update"`
 }
 
+var producersMap map[string]*Producer
+
 func (c *Conn) IsConnected() bool {
 	return c.brokerConn.IsConnected()
 }

--- a/connect.go
+++ b/connect.go
@@ -72,11 +72,11 @@ func (c *Conn) IsConnected() bool {
 	return c.brokerConn.IsConnected()
 }
 
-func (c *Conn) GetProducerMap() ProducersMap {
+func (c *Conn) getProducerMap() ProducersMap {
 	return c.producersMap
 }
 
-func (c *Conn) SetProducerMap(producersMap ProducersMap) {
+func (c *Conn) setProducerMap(producersMap ProducersMap) {
 	c.producersMap = producersMap
 }
 
@@ -268,7 +268,7 @@ func (c *Conn) startConn() error {
 
 func (c *Conn) Close() {
 	c.brokerConn.Close()
-	c.SetProducerMap(nil)
+	c.setProducerMap(nil)
 }
 
 func (c *Conn) brokerCorePublish(subject, reply string, msg []byte) error {
@@ -520,7 +520,7 @@ func GetDlsMsgId(stationName string, producerName string, timeSent string) strin
 }
 
 func (pm *ProducersMap) getProducer(key string) *Producer {
-	if (*pm)[key] != nil {
+	if (*pm) != nil && (*pm)[key] != nil {
 		return (*pm)[key]
 	}
 	return nil

--- a/connect.go
+++ b/connect.go
@@ -38,6 +38,8 @@ const configurationUpdatesSubject = "$memphis_sdk_configurations_updates"
 // Option is a function on the options for a connection.
 type Option func(*Options) error
 
+type ProducersMap map[string]*Producer
+
 type TLSOpts struct {
 	TlsCert string
 	TlsKey  string
@@ -66,7 +68,7 @@ type ConfigurationsUpdate struct {
 	Update      bool   `json:"update"`
 }
 
-var producersMap map[string]*Producer
+var producersMap = make(ProducersMap)
 
 func (c *Conn) IsConnected() bool {
 	return c.brokerConn.IsConnected()
@@ -506,4 +508,20 @@ func GetDlsMsgId(stationName string, producerName string, timeSent string) strin
 	msgId := strings.ReplaceAll(stationName+"~"+producerName+"~0~"+timeSent, " ", "")
 	msgId = strings.ReplaceAll(msgId, ",", "+")
 	return msgId
+}
+
+func (pm *ProducersMap) getProducer(n string) *Producer {
+	if (*pm)[n] != nil {
+		return (*pm)[n]
+	}
+	return nil
+}
+
+func (pm *ProducersMap) setProducer(p *Producer) {
+	pn := fmt.Sprintf("%s_%s", p.stationName, p.Name)
+
+	if pm.getProducer(pn) != nil {
+		return
+	}
+	(*pm)[pn] = p
 }

--- a/connect_test.go
+++ b/connect_test.go
@@ -44,7 +44,7 @@ func TestProduceNoProducer(t *testing.T) {
 		t.Error(err)
 	}
 
-	pm := c.GetProducerMap()
+	pm := c.getProducerMap()
 	pm.unsetStationProducers("station_name_c_produce")
 	p := pm.getProducer("producer_name_a")
 	if p != nil {

--- a/connect_test.go
+++ b/connect_test.go
@@ -26,3 +26,21 @@ func TestNormalizeHost(t *testing.T) {
 		t.Error()
 	}
 }
+
+func TestProduceNoProducer(t *testing.T) {
+	c, err := Connect("localhost", "root", "memphis")
+	if err != nil {
+		t.Error(err)
+	}
+	defer c.Close()
+
+	err = c.Produce("station_name_c_produce", "producer_name_a", []byte("Hey There!"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = c.Produce("station_name_c_produce", "producer_name_a", []byte("Hey! Test 2 pleaseee"))
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/connect_test.go
+++ b/connect_test.go
@@ -43,4 +43,11 @@ func TestProduceNoProducer(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	pm := c.GetProducerMap()
+	pm.unsetStationProducers("station_name_c_produce")
+	p := pm.getProducer("producer_name_a")
+	if p != nil {
+		t.Error("unsetStationProducers failed to remove key [station_name_c_produce]")
+	}
 }

--- a/producer.go
+++ b/producer.go
@@ -188,27 +188,23 @@ func (c *Conn) Produce(stationName, name string, message any, opts ...ProducerOp
 }
 
 func checkForProducerExistenceAndCreate(p *Producer) {
-	pn := fmt.Sprintf("%s_%s", p.stationName, p.Name)
-	if producersMap[pn] != nil {
-		return
-	}
-	producersMap[pn] = p
+	producersMap.setProducer(p)
 }
 
 func checkForProducerExistenceAndDelete(p *Producer) {
 	pn := fmt.Sprintf("%s_%s", p.stationName, p.Name)
-	if producersMap[pn] != nil {
+	if producersMap.getProducer(pn) == nil {
 		delete(producersMap, pn)
 	}
 }
 
 func checkForProducerExistence(stationName, name string) (error, *Producer) {
 	pn := fmt.Sprintf("%s_%s", stationName, name)
-	if producersMap[pn] != nil {
+	if producersMap.getProducer(pn) == nil {
 		return fmt.Errorf("%s not exists on the map", pn), nil
 	}
 
-	return nil, producersMap[pn]
+	return nil, producersMap.getProducer(pn)
 }
 
 // Station.CreateProducer - creates a producer attached to this station.

--- a/producer.go
+++ b/producer.go
@@ -167,12 +167,12 @@ func (c *Conn) CreateProducer(stationName, name string, opts ...ProducerOpt) (*P
 	}
 
 	if err = c.create(&p); err != nil {
-		checkForProducerExistenceAndCreate(&p)
 		if err := c.removeSchemaUpdatesListener(stationName); err != nil {
 			return nil, memphisError(err)
 		}
 		return nil, memphisError(err)
 	}
+	checkForProducerExistenceAndCreate(&p)
 
 	return &p, nil
 }

--- a/producer.go
+++ b/producer.go
@@ -173,7 +173,9 @@ func (c *Conn) CreateProducer(stationName, name string, opts ...ProducerOpt) (*P
 	return &p, nil
 }
 
-// Produce - produce a message without creating a new producer, using connection only
+// Produce - produce a message without creating a new producer, using connection only,
+// in cases where extra performance is needed the recommended way is to create a producer first
+// and produce messages by using the produce receiver function of it
 func (c *Conn) Produce(stationName, name string, message any, opts ...ProducerOpt) error {
 	if err, cp := c.getProducerFromCache(stationName, name); err == nil {
 		return cp.Produce(message, nil)
@@ -187,13 +189,13 @@ func (c *Conn) Produce(stationName, name string, message any, opts ...ProducerOp
 }
 
 func (c *Conn) cacheProducer(p *Producer) {
-	pm := c.GetProducerMap()
+	pm := c.getProducerMap()
 	pm.setProducer(p)
 }
 
 func (c *Conn) unCacheProducer(p *Producer) {
 	pn := fmt.Sprintf("%s_%s", p.stationName, p.Name)
-	pm := c.GetProducerMap()
+	pm := c.getProducerMap()
 	if pm.getProducer(pn) == nil {
 		pm.unsetProducer(pn)
 	}
@@ -201,7 +203,7 @@ func (c *Conn) unCacheProducer(p *Producer) {
 
 func (c *Conn) getProducerFromCache(stationName, name string) (error, *Producer) {
 	pn := fmt.Sprintf("%s_%s", stationName, name)
-	pm := c.GetProducerMap()
+	pm := c.getProducerMap()
 	if pm.getProducer(pn) == nil {
 		return fmt.Errorf("%s not exists on the map", pn), nil
 	}

--- a/station.go
+++ b/station.go
@@ -168,7 +168,15 @@ func (opts *StationOpts) createStation(c *Conn) (*Station, error) {
 type StationName string
 
 func (s *Station) Destroy() error {
-	return s.conn.destroy(s)
+	err := s.conn.destroy(s)
+	if err != nil {
+		return err
+	}
+
+	pm := s.conn.GetProducerMap()
+	pm.unsetStationProducers(s.Name)
+
+	return nil
 }
 
 func (s *Station) getCreationSubject() string {

--- a/station.go
+++ b/station.go
@@ -173,7 +173,7 @@ func (s *Station) Destroy() error {
 		return err
 	}
 
-	pm := s.conn.GetProducerMap()
+	pm := s.conn.getProducerMap()
 	pm.unsetStationProducers(s.Name)
 
 	return nil


### PR DESCRIPTION
Adding new Produce func under the connection struct
in order to be able to send a message without creating a new Producer.
Checking if we already have a producer ready to use or we create a new one
and save it under a map.