### PR TITLE
feat: add support for access token generation and validation

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,98 @@
+package memphis
+
+import (
+	"encoding/json"
+	"time"
+)
+
+const (
+	accessTokenValidationSubject = "$memphis_access_token_validation"
+	accessTokenGenerationSubject = "$memphis_access_token_generation"
+)
+
+type AccessTokenResp struct {
+	AccessKeyID string `json:"access_key_id"`
+	SecretKey   string `json:"secret_key"`
+}
+
+type generateAccessTokenReq struct {
+	Description string `json:"description"`
+	Username    string `json:"username"`
+}
+
+type generateAccessTokenResp struct {
+	AccessKeyID string `json:"access_key_id"`
+	SecretKey   string `json:"secret_key"`
+	Err         string `json:"error"`
+}
+
+type validateAccessTokenReq struct {
+	AccessKeyID string `json:"access_key_id"`
+	SecretKey   string `json:"secret_key"`
+}
+
+type validateAccessTokenResp struct {
+	IsValid bool   `json:"is_valid"`
+	Err     string `json:"error"`
+}
+
+func (c *Conn) GenerateAccessToken(username, description string) (*AccessTokenResp, error) {
+	req := generateAccessTokenReq{
+		Username:    username,
+		Description: description,
+	}
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, memphisError(err)
+	}
+
+	msg, err := c.brokerConn.Request(accessTokenGenerationSubject, b, 20*time.Second)
+	if err != nil {
+		return nil, memphisError(err)
+	}
+
+	ar := &generateAccessTokenResp{}
+	err = json.Unmarshal(msg.Data, ar)
+	if err != nil {
+		return nil, defaultHandleCreationResp(msg.Data)
+	}
+
+	if ar.Err != "" {
+		return nil, defaultHandleCreationResp([]byte(ar.Err))
+	}
+
+	return &AccessTokenResp{
+		AccessKeyID: ar.AccessKeyID,
+		SecretKey:   ar.SecretKey,
+	}, nil
+}
+
+func (c *Conn) ValidateAccessToken(accessKeyID, secretKey string) (bool, error) {
+	req := validateAccessTokenReq{
+		AccessKeyID: accessKeyID,
+		SecretKey:   secretKey,
+	}
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		return false, memphisError(err)
+	}
+
+	msg, err := c.brokerConn.Request(accessTokenValidationSubject, b, 20*time.Second)
+	if err != nil {
+		return false, memphisError(err)
+	}
+
+	vr := &validateAccessTokenResp{}
+	err = json.Unmarshal(msg.Data, vr)
+	if err != nil {
+		return false, defaultHandleCreationResp(msg.Data)
+	}
+
+	if vr.Err != "" {
+		return false, defaultHandleCreationResp([]byte(vr.Err))
+	}
+
+	return vr.IsValid, nil
+}

--- a/auth.go
+++ b/auth.go
@@ -10,7 +10,7 @@ const (
 	accessTokenGenerationSubject = "$memphis_access_token_generation"
 )
 
-type AccessTokenResp struct {
+type AccessToken struct {
 	AccessKeyID string `json:"access_key_id"`
 	SecretKey   string `json:"secret_key"`
 }
@@ -36,7 +36,7 @@ type validateAccessTokenResp struct {
 	Err     string `json:"error"`
 }
 
-func (c *Conn) GenerateAccessToken(username, description string) (*AccessTokenResp, error) {
+func (c *Conn) GenerateAccessToken(username, description string) (*AccessToken, error) {
 	req := generateAccessTokenReq{
 		Username:    username,
 		Description: description,
@@ -62,7 +62,7 @@ func (c *Conn) GenerateAccessToken(username, description string) (*AccessTokenRe
 		return nil, defaultHandleCreationResp([]byte(ar.Err))
 	}
 
-	return &AccessTokenResp{
+	return &AccessToken{
 		AccessKeyID: ar.AccessKeyID,
 		SecretKey:   ar.SecretKey,
 	}, nil


### PR DESCRIPTION
## Context
* This PR contains feature to create and validate access tokens (stored in broker)

## Issue & Relevant PRs
* This enhancements will be subpart of following issue https://github.com/memphisdev/memphis-rest-gateway/issues/51
* Following are relevant PRs
    1. https://github.com/memphisdev/memphis/pull/1342

## Examples
Create New Access Token via SDK

### Method
```
generatedTokenData, err := conn.GenerateAccessToken(username, body.Description)
```
### Output
```
AccessToken{
   AccessKeyID:  "string",
   SecretKey:   "string",
}
```

Validate Access Token via SDK

### Method
```
isValid, err := conn.ValidateAccessToken(accessKeyId, secretKey)
```
`isValid` is true if valid `accessKeyId` and `secretKey` is valid or false if invalid

