### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,18 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
-
-      - name: Download docker-compose file
-        run: |
-          curl -s https://memphisdev.github.io/memphis-docker/docker-compose-dev.yml -o docker-compose.yaml
-
-      - name: Run docker-compose file
-        run: docker compose -f docker-compose.yaml -p memphis up -d
+          go-version: 1.19.13
 
       - name: Test
         run: go test -v
-
-      - name: Stop and remove running containers
-        run: |
-          docker compose down

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,8 @@ node ("small-ec2-fleet") {
   
   try{
     stage ('Install GoLang') {
-      sh 'wget -q https://go.dev/dl/go1.18.4.linux-amd64.tar.gz'
-      sh 'sudo  tar -C /usr/local -xzf go1.18.4.linux-amd64.tar.gz'
+      sh 'wget -q https://go.dev/dl/go1.19.13.linux-amd64.tar.gz'
+      sh 'sudo  tar -C /usr/local -xzf go1.19.13.linux-amd64.tar.gz'
     }
     
     stage('Deploy GO SDK') {

--- a/README.md
+++ b/README.md
@@ -828,6 +828,3 @@ consumer.Destroy();
 ```go
 conn.IsConnected()
 ```
-
-# Test status [![Test](https://github.com/memphisdev/memphis.go/actions/workflows/test.yml/badge.svg)](https://github.com/memphisdev/memphis.go/actions/workflows/test.yml)
-

--- a/README.md
+++ b/README.md
@@ -828,3 +828,6 @@ consumer.Destroy();
 ```go
 conn.IsConnected()
 ```
+
+# Test status [![Test](https://github.com/memphisdev/memphis.go/actions/workflows/test.yml/badge.svg)](https://github.com/memphisdev/memphis.go/actions/workflows/test.yml)
+

--- a/README.md
+++ b/README.md
@@ -827,3 +827,6 @@ consumer.Destroy();
 ```go
 conn.IsConnected()
 ```
+
+# Test status [![Test](https://github.com/memphisdev/memphis.go/actions/workflows/test.yml/badge.svg)](https://github.com/memphisdev/memphis.go/actions/workflows/test.yml)
+

--- a/_configuration/dev.env
+++ b/_configuration/dev.env
@@ -1,0 +1,2 @@
+COMPOSEURL=https://memphisdev.github.io/memphis-docker/docker-compose-dev.yml
+

--- a/connect_test.go
+++ b/connect_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestConnect(t *testing.T) {
-	c, err := Connect("localhost", "root", ConnectionToken("memphis"))
+	c, err := Connect("localhost", "root", Password("memphis"))
 	if err != nil {
 		t.Error()
 		return
@@ -28,7 +28,7 @@ func TestNormalizeHost(t *testing.T) {
 }
 
 func TestProduceNoProducer(t *testing.T) {
-	c, err := Connect("localhost", "root", ConnectionToken("memphis"))
+	c, err := Connect("localhost", "root", Password("memphis"))
 	if err != nil {
 		t.Error(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/memphisdev/memphis.go
 
-go 1.18
+go 1.19.13
 
 require (
 	github.com/graph-gophers/graphql-go v1.5.0
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/g41797/sputnik v0.0.21
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/hamba/avro/v2 v2.13.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.1.0
@@ -16,6 +17,10 @@ require (
 )
 
 require (
+	github.com/g41797/godotenv v1.5.3 // indirect
+	github.com/g41797/gonfig v1.0.1 // indirect
+	github.com/g41797/kissngoqueue v0.1.5 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
@@ -28,4 +33,5 @@ require (
 	golang.org/x/crypto v0.6.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/memphisdev/memphis.go
 
-go 1.19.13
+go 1.19
 
 require (
 	github.com/graph-gophers/graphql-go v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,16 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/g41797/godotenv v1.5.3 h1:/36/ofF29iNsZBvSS+L/yZk9Nw1SBULvbrV/tG17JMw=
+github.com/g41797/godotenv v1.5.3/go.mod h1:0l6Y57HWL8UW+JO772pthnF0QCvi9zlJigl/JW7ug9Q=
+github.com/g41797/gonfig v1.0.1 h1:ywgkhF3SbNJuFN9Hlm9n7Lp+KxqeupkNmFObn2ZpWs8=
+github.com/g41797/gonfig v1.0.1/go.mod h1:5iL4oHFpYi+c7AE4D1dZnlBleJzM71dX6HZBhEELF90=
+github.com/g41797/kissngoqueue v0.1.5 h1:UrnpxbjOnTnKj/EqpbLA9LjhYkHjnLWMZQqsz3AOBG8=
+github.com/g41797/kissngoqueue v0.1.5/go.mod h1:c1mGfrNWfEP2cHeX04Iji8qYGQevvUmZw5SPZM5M9Cs=
+github.com/g41797/sputnik v0.0.21 h1:+nIr3o5t7P3H/blUKANVay7/S4ziLsacLQ0sIY6k7cQ=
+github.com/g41797/sputnik v0.0.21/go.mod h1:LZls2fb5MC8TtSioolMtmKpnWHmFR6mg9zjTmynukw4=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
@@ -63,7 +73,10 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,118 @@
+package memphis
+
+import (
+	"embed"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/g41797/sputnik/sidecar"
+	"github.com/nats-io/nats.go"
+)
+
+//go:embed _configuration
+var embconf embed.FS
+
+func TestMain(m *testing.M) {
+	os.Exit(testMain(m))
+}
+
+// second level function, because os.Exit does not honor defer
+func testMain(m *testing.M) int {
+
+	clean, err := prepareTestEnvironment(&embconf)
+	defer clean()
+
+	if err != nil {
+		return -1
+	}
+
+	return m.Run()
+}
+
+// Ensure running tests in ready environment
+func prepareTestEnvironment(embconf *embed.FS) (cleanFunc func(), err error) {
+
+	cleaner := new(sidecar.Cleaner)
+
+	// Create configuration and env files from embedded ones
+	cleanUp, err := sidecar.UseEmbeddedConfiguration(embconf)
+	if err != nil {
+		return cleaner.Clean, err
+	}
+
+	cleaner.Push(cleanUp)
+
+	// Setup environment variables from env files
+	// Replaces vscode setting in launch.json file
+	// Reason - running tests in github without vscode
+	err = sidecar.LoadEnv()
+	if err != nil {
+		return cleaner.Clean, err
+	}
+
+	composeurl, exists := os.LookupEnv("COMPOSEURL")
+
+	if !exists {
+		composeurl = os.Getenv("DEV_COMPOSEURL")
+	}
+
+	if err = sidecar.LoadDockerComposeFile(composeurl); err != nil {
+		return cleaner.Clean, err
+	}
+
+	// Start broker and additional servers using docker compose file
+	stop, err := sidecar.StartServices()
+	if err != nil {
+		return cleaner.Clean, err
+	}
+	cleaner.Push(stop)
+
+	conn := waitStart()
+	cleaner.Push(func() { conn.Close() })
+
+	return cleaner.Clean, nil
+
+}
+
+func waitStart() *nats.Conn {
+	ticker := time.NewTicker(1 * time.Second)
+	for {
+		select {
+		case <-ticker.C:
+			conn, err := connect()
+			if err == nil {
+				ticker.Stop()
+				return conn
+			}
+		}
+	}
+}
+
+func connect() (*nats.Conn, error) {
+
+	url := "localhost:6666"
+	username := "root"
+	creds := "memphis"
+	name := "MEMPHIS HTTP LOGGER"
+
+	var nc *nats.Conn
+	var err error
+
+	natsOpts := nats.Options{
+		Url:            url,
+		AllowReconnect: true,
+		MaxReconnect:   10,
+		ReconnectWait:  3 * time.Second,
+		Name:           name,
+		Password:       creds,
+		User:           username,
+	}
+
+	nc, err = natsOpts.Connect()
+	if err != nil {
+		return nil, err
+	}
+
+	return nc, nil
+}

--- a/station.go
+++ b/station.go
@@ -462,7 +462,7 @@ func (c *Conn) removeFunctionsUpdatesListener(stationName string) error {
 
 	sfs, ok := c.stationFunctionSubs[sn]
 	if !ok {
-		return memphisError(errors.New("functions listener doesn't exist"))
+		return nil
 	}
 
 	sfs.StationFunctionsMu.Lock()
@@ -488,7 +488,7 @@ func (c *Conn) removeSchemaUpdatesListener(stationName string) error {
 	defer stationUpdatesSubsLock.Unlock()
 	sus, ok := c.stationUpdatesSubs[sn]
 	if !ok {
-		return memphisError(errors.New("listener doesn't exist"))
+		return nil
 	}
 
 	sus.refCount--
@@ -511,7 +511,7 @@ func (c *Conn) getSchemaDetails(stationName string) (schemaDetails, error) {
 
 	sus, ok := c.stationUpdatesSubs[sn]
 	if !ok {
-		return schemaDetails{}, memphisError(errors.New("station subscription doesn't exist"))
+		return schemaDetails{}, nil
 	}
 
 	return sus.schemaDetails, nil

--- a/station_test.go
+++ b/station_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestCreateStation(t *testing.T) {
-	c, err := Connect("localhost", "root", ConnectionToken("memphis"))
+	c, err := Connect("localhost", "root", Password("memphis"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -46,7 +46,7 @@ func TestCreateStation(t *testing.T) {
 }
 
 func TestRemoveStation(t *testing.T) {
-	c, err := Connect("localhost", "root", ConnectionToken("memphis"))
+	c, err := Connect("localhost", "root", Password("memphis"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -64,7 +64,7 @@ func TestRemoveStation(t *testing.T) {
 }
 
 func TestCreateStationWithDefaults(t *testing.T) {
-	c, err := Connect("localhost", "root", ConnectionToken("memphis"))
+	c, err := Connect("localhost", "root", Password("memphis"))
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Tests log on the local computer:
```bash
~/go/pkg/mod/github.com/memphisdev/memphis.go$ go test -v
=== RUN   TestConnect
--- PASS: TestConnect (1.02s)
=== RUN   TestNormalizeHost
--- PASS: TestNormalizeHost (0.00s)
=== RUN   TestProduceNoProducer
--- PASS: TestProduceNoProducer (1.02s)
=== RUN   TestCreateProducer
--- PASS: TestCreateProducer (1.16s)
=== RUN   TestProduce
--- PASS: TestProduce (1.09s)
=== RUN   TestRemoveProducer
--- PASS: TestRemoveProducer (1.10s)
=== RUN   TestFetch
2023/11/26 12:03:14 Consumer consumer_a: station unreachable
2023/11/26 12:03:14 Consumer consumer_a: consumer is inactive
--- PASS: TestFetch (1.11s)
=== RUN   TestConsume
--- PASS: TestConsume (1.10s)
=== RUN   TestCreateConsumer
--- PASS: TestCreateConsumer (1.11s)
=== RUN   TestRemoveConsumer
--- PASS: TestRemoveConsumer (1.11s)
=== RUN   TestFullFlow
--- PASS: TestFullFlow (0.18s)
=== RUN   TestCreateSchema
sdk_test_schema_graphql already exist in the db
sdk_test_schema_protobuf2 already exist in the db
sdk_test_schema_protobuf3 already exist in the db
sdk_test_schema_json already exist in the db
sdk_test_schema_avro already exist in the db
--- PASS: TestCreateSchema (1.02s)
=== RUN   TestCreateStation
--- PASS: TestCreateStation (1.22s)
=== RUN   TestRemoveStation
--- PASS: TestRemoveStation (1.19s)
=== RUN   TestCreateStationWithDefaults
--- PASS: TestCreateStationWithDefaults (1.08s)
PASS
ok      github.com/memphisdev/memphis.go        16.109s
```
Docker images automatically downloaded and composed by test.
Url of docker-compose.yml taken from [dev.env](https://github.com/memphisdev/memphis.go/blob/master/_configuration/dev.env) file:
```bash
COMPOSEURL=https://memphisdev.github.io/memphis-docker/docker-compose-dev.yml
```

